### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -10,4 +10,4 @@ PackageName: IR2Reg
 PackageOwner: nathanemac
 PackageUUID: d8b20677-8476-5485-a89f-d14abca248d9
 _commit: v0.10.1
-_src_path: https://github.com/abelsiqueira/BestieTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
